### PR TITLE
Update driver_read.f90

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,5 @@ o  BUGSRAD contains separate albedo values for shortwave and near IR. I've set t
 
 o  BUGSRAD has its own precision definitions (e.g. dbl_kind). They're still being used and aren't interfaced with the options to compile with double or single precision in the Makefile.
 
-o  Three of the new BUGSRAD source files are .f. These don't play well with archiving, so they will compile every time and you'll get a warning about it.
-
 I've also added RTE+RRTMGP radiation (https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2019MS001621) as option 5
 

--- a/src/micro/mic_nuc.f90
+++ b/src/micro/mic_nuc.f90
@@ -13,7 +13,7 @@ real, dimension(m1) :: rv,wp,dn0
 real :: tairc_nuc,w_nuc,rg_nuc,tab,sfcareatotal
 real :: rjw,wtw1,wtw2,rjconcen,wtcon1,wtcon2,jrg1,jrg2,eps1,eps2
 real :: total_cld_nucc,total_drz_nucc,total_cld_nucr,total_drz_nucr
-real, dimension(9) :: concen_tab
+real, dimension(aerocat) :: concen_tab
 
 !Re-set cloud layer before nucleation
 k1cnuc = 2

--- a/src/radiate/bugs_files.f90
+++ b/src/radiate/bugs_files.f90
@@ -1814,7 +1814,7 @@
       end do  !i=1,ncol
  
       return
-      end
+      end subroutine two_rt_lw_iter
 
 
 ! CVS:  $Id: two_rt_lw_sel.F,v 1.3 2003/11/11 21:55:13 norm Exp $
@@ -1912,8 +1912,8 @@
           fd(i,1) = 0.
 
           do l=1,nlm
-            exptau(l) = exp(-2*tauclr(i,l))
-            if(tauclr(i,l) .lt. .8e-2) then
+            exptau(l) = exp(-2.*tauclr(i,l))
+            if(tauclr(i,l) .lt. 0.8e-2) then
               sigu(l) = (bf(i,l)+bf(i,l+1))*tauclr(i,l)
               sigd(l) = sigu(l)
             else
@@ -1934,7 +1934,7 @@
 1000  continue
 
       return
-      end
+      end subroutine two_rt_lw_sel
 
 
 ! CVS:  $Id: two_rt_sw_bs.F,v 1.3 2003/11/11 21:55:13 norm Exp $
@@ -2108,7 +2108,7 @@
 !            fudif(i,nlm+1) = fddir(i,nlm+1) * asdir(i,ib)
 ! 
 !            do l=nlm,1,-1
-!               fudif(i,l) = fudif(i,l+1) * exp(-2*tau(i,l))
+!               fudif(i,l) = fudif(i,l+1) * exp(-2.*tau(i,l))
 !            enddo
 ! 
 !            cycle

--- a/src/radiate/bugs_files.f90
+++ b/src/radiate/bugs_files.f90
@@ -7,14 +7,14 @@
 !-----------------------------------------------------------------------
 
       subroutine bugs_lwr &
-                     (    ncol ,    nlm ,    pp ,    ppl &
-     ,                      dp ,     tt ,  rmix ,  cwrho &
-     ,                     cwn  &
-     ,                   cirho ,  o3mix ,    ts , cldamt &
-     ,                  cldmax ,     b1 ,    b2 ,     b3 &
-     ,                      b4 ,  umco2 , umch4 ,  umn2o &
-     ,                    fdlw , fdlwcl ,  fulw , fulwcl &
-     ,               sel_rules &
+                     (    ncol ,    nlm ,    pp ,    ppl, &
+                            dp ,     tt ,  rmix ,  cwrho, &
+                           cwn ,  &
+                         cirho ,  o3mix ,    ts , cldamt, &
+                        cldmax ,     b1 ,    b2 ,     b3, &
+                            b4 ,  umco2 , umch4 ,  umn2o, &
+                          fdlw , fdlwcl ,  fulw , fulwcl, &
+                     sel_rules &
                      )
      
       use bugs_kinds

--- a/src/radiate/bugs_files.f90
+++ b/src/radiate/bugs_files.f90
@@ -114,10 +114,10 @@
 !     OUTPUT ARGUMENTS:
 !     -----------------
       real (kind=dbl_kind), intent(out), dimension(ncol,nlm+1):: &
-       fdlw   & !Downward LW flux                            (W/m^2).
-     , fdlwcl & !Downward clear-ksy LW flux                  (W/m^2).
-     , fulw   & !Upward LW flux                              (W/m^2).
-     , fulwcl  !Upward clear-sky LW flux                     (W/m^2).
+       fdlw,   & !Downward LW flux                           (W/m^2).
+       fdlwcl, & !Downward clear-ksy LW flux                 (W/m^2).
+       fulw,   & !Upward LW flux                             (W/m^2).
+       fulwcl  !Upward clear-sky LW flux                     (W/m^2).
 
 ! LOCAL VARIABLES:
 

--- a/src/radiate/driver_read.f90
+++ b/src/radiate/driver_read.f90
@@ -96,10 +96,20 @@
       nlen = 1    !to do timing tests
       len = nlen
 !----
-      do l=2,nlm+1
+! AJD changed: original:
+!      do l=2,nlm+1
+!       pl2(1,l)=(pl(1,l-1)+pl(1,l))/2.
+!      enddo
+!      pl2(1,1)=pl2(1,2)+abs(pl2(1,2)-pl2(1,3))
+! Bug in original: pl(1,nlm+1) is not defined!
+!
+! AJD changed: modified:
+      do l=2,nlm
        pl2(1,l)=(pl(1,l-1)+pl(1,l))/2.
       enddo
       pl2(1,1)=pl2(1,2)+abs(pl2(1,2)-pl2(1,3))
+! AJD - extrapolate to the top-layer pressure:
+      pl2(1,nlm+1)=pl2(1,nlm)-abs(pl2(1,nlm-1)-pl2(1,nlm))
 
       pl = pl/100. !convert from Pascals to millibars
       pl2 = pl2/100. 


### PR DESCRIPTION
There was a bug where the value of pl2(1,nlm+1) depends on the value of pl(1,nlm+1). The problem is that pl has dimension (1,nlm). I implemented a crude fix in which pl2(1,nlm+1) is instead calculated by extrapolating from pl2(1,nlm-1) and pl2(1,nlm). See AJD comments.